### PR TITLE
Improve mobile before/after layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -359,3 +359,9 @@ input[type="text"] {
     width: 90%;
   }
 }
+
+@media (max-width: 600px) {
+  .before-after-container {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## Summary
- tweak styles for before/after carousel on small screens

## Testing
- `python3 -m http.server` *(fails: terminated)*